### PR TITLE
Fix vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
-  "build": {
-    "outputDirectory": "public"
-  },
+  "outputDirectory": "public",
   "functions": {
     "api/steam-user.mjs": {
       "maxDuration": 10


### PR DESCRIPTION
## Summary
- set `outputDirectory` at the root of `vercel.json`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883d0347c60832182f00e07573e4450