### PR TITLE
Fix win/loss detection in player search

### DIFF
--- a/public/js/data-models.js
+++ b/public/js/data-models.js
@@ -128,8 +128,9 @@ class PlayerProfile {
     calculateRecentForm() {
         if (!this.recentMatches || this.recentMatches.length === 0) return [];
         
+        // Deadlock API uses 0 for wins and 1 for losses
         return this.recentMatches.slice(0, 10).map(match =>
-            Number(match.match_result) === 1 ? 'W' : 'L'
+            Number(match.match_result) === 0 ? 'W' : 'L'
         );
     }
 

--- a/public/js/deadlock-api-service.js
+++ b/public/js/deadlock-api-service.js
@@ -543,11 +543,11 @@ class DeadlockAPIService {
             const kills = match.player_kills || match.kills || 0;
             const deaths = match.player_deaths || match.deaths || 0;
             const assists = match.player_assists || match.assists || 0;
-            const matchResult = Number(match.match_result);
+            const matchResult = Number(match.match_result); // 0 = win, 1 = loss
             const heroId = match.hero_id;
             
             // Win/loss tracking
-            if (matchResult === 1) {
+            if (matchResult === 0) {
                 stats.wins++;
             } else {
                 stats.losses++;
@@ -555,7 +555,7 @@ class DeadlockAPIService {
 
             // Recent form (last 10 matches)
             if (index < 10) {
-                stats.recentForm.push(matchResult === 1 ? 'W' : 'L');
+                stats.recentForm.push(matchResult === 0 ? 'W' : 'L');
             }
 
             // KDA tracking
@@ -578,7 +578,7 @@ class DeadlockAPIService {
                 }
                 
                 stats.heroStats[heroId].matches++;
-                if (matchResult === 1) {
+                if (matchResult === 0) {
                     stats.heroStats[heroId].wins++;
                 } else {
                     stats.heroStats[heroId].losses++;

--- a/public/js/player-search.js
+++ b/public/js/player-search.js
@@ -245,7 +245,7 @@ class PlayerSearch {
                     start_time: match.start_time
                 });
                 
-                const resultValue = Number(match.match_result);
+                const resultValue = Number(match.match_result); // 0 = win, 1 = loss
 
                 return {
                     matchId: match.match_id,
@@ -255,7 +255,7 @@ class PlayerSearch {
                     kills: match.player_kills || 0,
                     deaths: match.player_deaths || 0,
                     assists: match.player_assists || 0,
-                    result: resultValue === 1 ? 'win' : 'loss',
+                    result: resultValue === 0 ? 'win' : 'loss',
                     startTime: new Date(match.start_time * 1000).toISOString(),
                     duration: match.match_duration_s || 0,
                     playerDamage: 0, // Not available in this endpoint


### PR DESCRIPTION
## Summary
- correct result parsing for recent form and stats
- fix win/loss mapping when processing player match history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883d0fdbff48321bc662d4b33ad3721