### PR TITLE
Add lane economics timing note

### DIFF
--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -311,6 +311,9 @@ class MatchAnalyzer {
                 <!-- Lane Comparison Summary -->
                 <div class="mt-6 pt-6 border-t border-gray-600">
                     ${this.createLaneComparisonSummary(team0Players, team1Players)}
+                    <p class="text-xs text-gray-500 text-center mt-4">
+                        Lane Economics &amp; Farm stats should be collected from the data before the first tower is destroyed on either side.
+                    </p>
                 </div>
             </section>
         `;


### PR DESCRIPTION
## Summary
- notify players that lane economics & farm stats should be gathered before the first tower falls

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883df37d38083218a2c5b2cd36f5476