### PR TITLE
Fix BigInt usage for older browsers

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,5 +1,6 @@
 import API_CONFIG from '../config/api-config.js';
 import DeadlockAPIService from './deadlock-api-service.js';
+import { accountIdToSteamId64 } from './bigint-utils.js';
 
 // Simple request tracking
 let requestCount = 0;
@@ -11,8 +12,8 @@ let deadlockAPI = new DeadlockAPIService();
 // Steam Profile Name Fetching (using Vercel serverless function)
 async function getSteamProfileName(steamId) {
     try {
-        // Convert 32-bit account ID to 64-bit Steam ID
-        const steamId64 = (BigInt(steamId) + BigInt('76561197960265728')).toString();
+        // Convert 32-bit account ID to 64-bit Steam ID with BigInt fallback
+        const steamId64 = accountIdToSteamId64(steamId);
         
         // Use Vercel serverless function instead of CORS proxy
         const response = await fetch(`/api/steam-user?steamids=${steamId64}`);

--- a/public/js/bigint-utils.js
+++ b/public/js/bigint-utils.js
@@ -1,0 +1,61 @@
+export function addStrings(a, b) {
+    let carry = 0;
+    let result = '';
+    a = a.toString().split('').reverse();
+    b = b.toString().split('').reverse();
+    const len = Math.max(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+        const digitA = parseInt(a[i] || '0', 10);
+        const digitB = parseInt(b[i] || '0', 10);
+        const sum = digitA + digitB + carry;
+        result = (sum % 10) + result;
+        carry = Math.floor(sum / 10);
+    }
+    if (carry) result = carry + result;
+    return result;
+}
+
+export function subtractStrings(a, b) {
+    let borrow = 0;
+    let result = '';
+    a = a.toString().split('').reverse();
+    b = b.toString().split('').reverse();
+    for (let i = 0; i < a.length; i++) {
+        let digitA = parseInt(a[i], 10) - borrow;
+        const digitB = parseInt(b[i] || '0', 10);
+        if (digitA < digitB) {
+            digitA += 10;
+            borrow = 1;
+        } else {
+            borrow = 0;
+        }
+        const diff = digitA - digitB;
+        result = diff + result;
+    }
+    result = result.replace(/^0+/, '');
+    return result || '0';
+}
+
+export function accountIdToSteamId64(accountId) {
+    if (!accountId) return null;
+    try {
+        if (typeof BigInt !== 'undefined') {
+            return (BigInt(accountId) + 76561197960265728n).toString();
+        }
+    } catch (e) {
+        console.warn('BigInt conversion failed:', e);
+    }
+    return addStrings(accountId.toString(), '76561197960265728');
+}
+
+export function steamId64ToAccountId(steamId64) {
+    if (!steamId64) return null;
+    try {
+        if (typeof BigInt !== 'undefined') {
+            return (BigInt(steamId64) - 76561197960265728n).toString();
+        }
+    } catch (e) {
+        console.warn('BigInt conversion failed:', e);
+    }
+    return subtractStrings(steamId64.toString(), '76561197960265728');
+}

--- a/public/js/deadlock-api-service.js
+++ b/public/js/deadlock-api-service.js
@@ -5,6 +5,7 @@
 
 // Import hero mappings for better asset handling
 import { getHeroClassName, getHeroName } from '../hero_mapping/hero-mappings.js';
+import { accountIdToSteamId64 } from './bigint-utils.js';
 
 class DeadlockAPIService {
     constructor() {
@@ -154,8 +155,8 @@ class DeadlockAPIService {
             const playerCopy = { ...player };
             
             try {
-                // Convert 32-bit account ID to 64-bit Steam ID
-                const steamId64 = (BigInt(player.accountId) + BigInt('76561197960265728')).toString();
+                // Convert 32-bit account ID to 64-bit Steam ID with BigInt fallback
+                const steamId64 = accountIdToSteamId64(player.accountId);
                 
                 // Use Vercel serverless function
                 const response = await fetch(`/api/steam-user?steamids=${steamId64}`);

--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -3,7 +3,7 @@
  */
 
 import DeadlockAPIService from './deadlock-api-service.js';
-import { 
+import {
     HERO_ID_TO_NAME, 
     HERO_ID_TO_CLASS, 
     HERO_COLORS,
@@ -11,6 +11,7 @@ import {
     getHeroClassName,
     getHeroColor
 } from '../hero_mapping/hero-mappings.js';
+import { accountIdToSteamId64 } from './bigint-utils.js';
 
 // Match Analyzer Component
 class MatchAnalyzer {
@@ -595,7 +596,7 @@ class MatchAnalyzer {
     convertToSteamId(accountId) {
         if (!accountId) return null;
         try {
-            return (BigInt(accountId) + BigInt('76561197960265728')).toString();
+            return accountIdToSteamId64(accountId);
         } catch (error) {
             console.warn('Error converting to Steam ID:', error);
             return null;

--- a/public/js/player-search.js
+++ b/public/js/player-search.js
@@ -4,6 +4,7 @@
 
 import DeadlockAPIService from './deadlock-api-service.js';
 import { getHeroName, getHeroColor } from '../hero_mapping/hero-mappings.js';
+import { steamId64ToAccountId } from './bigint-utils.js';
 
 class PlayerSearch {
     constructor() {
@@ -170,9 +171,8 @@ class PlayerSearch {
             
             console.log(`Fetching recent matches for SteamID64: ${steamId64}`);
             
-            // Convert SteamID64 to account ID for Deadlock API
-            // SteamID64 to Account ID: subtract 76561197960265728
-            const accountId = BigInt(steamId64) - BigInt('76561197960265728');
+            // Convert SteamID64 to account ID for Deadlock API with BigInt fallback
+            const accountId = steamId64ToAccountId(steamId64);
             console.log(`Converted to account ID: ${accountId}`);
             
             // Call the Deadlock API directly since we know the correct endpoint format


### PR DESCRIPTION
## Summary
- add helper functions to handle SteamID math without requiring `BigInt`
- use the new helpers in all browser-side scripts

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883e0fe303483218097463660c31ad8