### PR TITLE
Add fairness score to player match cards

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -1872,4 +1872,16 @@ section {
     margin-left: auto;
     margin-right: auto;
 }
+
+/* Fairness badge shown on match cards */
+.fairness-badge {
+    background: rgba(234, 179, 8, 0.15);
+    border: 1px solid rgba(234, 179, 8, 0.3);
+    color: #eab308;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
 }


### PR DESCRIPTION
## Summary
- cache fairness scores for matches
- compute fairness using team stats
- fetch fairness for each match card when listing a player's matches
- style fairness badge in enhanced styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883e24ee3a08321a4836ca5fd0ac77f