### PR TITLE
Narrow player cards in history section

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -299,7 +299,7 @@ section {
 /* Mobile-responsive player cards */
 .player-stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 1rem;
 }
 
@@ -1409,7 +1409,7 @@ section {
     .historical-data-section .team-cards {
         display: grid;
         grid-auto-flow: column;
-        grid-auto-columns: 220px;
+        grid-auto-columns: 200px;
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
         gap: 1rem;
@@ -1431,7 +1431,7 @@ section {
     }
 
     .historical-data-section .player-card {
-        min-width: 220px;
+        min-width: 200px;
     }
 }
 
@@ -1487,7 +1487,7 @@ section {
 /* Player Historical Stats Grid Layout */
 .player-stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 1.5rem;
     padding: 1rem 0;
 }


### PR DESCRIPTION
## Summary
- adjust `player-stats-grid` card width to be narrower
- reduce mobile grid column width for historical player cards

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883f139669083219da0c10561eabc77