### PR TITLE
Add horizontal scrolling to historical player stats

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -1358,6 +1358,8 @@ section {
 /* Two-column team layout for historical data */
 .teams-container {
     position: relative;
+    overflow-x: auto;
+    scroll-behavior: smooth;
 }
 
 /* Desktop grid layout */
@@ -1367,9 +1369,9 @@ section {
 
 @media (min-width: 1024px) {
     .teams-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
+        display: flex;
         gap: 2rem;
+        width: max-content;
     }
     
     .teams-tabs {
@@ -1379,6 +1381,12 @@ section {
 
 .team-column {
     position: relative;
+}
+
+@media (min-width: 1024px) {
+    .team-column {
+        min-width: 600px;
+    }
 }
 
 .team-header {
@@ -1913,5 +1921,34 @@ section {
     font-size: 0.75rem;
     font-weight: 600;
     white-space: nowrap;
+}
+
+/* Horizontal scroll buttons for historical section */
+.teams-scroll-btn {
+    display: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(17, 24, 39, 0.8);
+    border: 1px solid rgba(75, 85, 99, 0.6);
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    cursor: pointer;
+    z-index: 20;
+}
+
+.teams-scroll-btn-left {
+    left: 0.25rem;
+}
+
+.teams-scroll-btn-right {
+    right: 0.25rem;
+}
+
+@media (min-width: 1024px) {
+    .teams-scroll-btn {
+        display: block;
+    }
 }
 }

--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -564,9 +564,11 @@ class MatchAnalyzer {
         return `
             <section class="historical-data-section animate-fadeInUp mb-8" style="animation-delay: 0.4s;">
                 <h2 class="text-2xl font-bold text-white mb-6 text-center">📊 Player Historical Performance</h2>
-                
+
                 <!-- Two-column layout wrapper -->
                 <div class="teams-container" id="teamsContainer">
+                    <button class="teams-scroll-btn teams-scroll-btn-left" id="teamsScrollLeft">&#9664;</button>
+                    <button class="teams-scroll-btn teams-scroll-btn-right" id="teamsScrollRight">&#9654;</button>
                     <!-- Two-column grid layout -->
                     <div class="teams-grid">
                         <!-- Team 1 Column -->
@@ -972,6 +974,9 @@ class MatchAnalyzer {
         
         // Add mobile tab functionality
         this.initializeTeamTabs();
+
+        // Add horizontal scroll controls for historical section
+        this.initializeHistoricalScroll();
         
     }
 
@@ -1692,6 +1697,25 @@ class MatchAnalyzer {
                     }
                 });
             });
+        });
+    }
+
+    /**
+     * Setup horizontal scrolling for historical player section
+     */
+    initializeHistoricalScroll() {
+        const container = document.getElementById('teamsContainer');
+        const leftBtn = document.getElementById('teamsScrollLeft');
+        const rightBtn = document.getElementById('teamsScrollRight');
+
+        if (!container || !leftBtn || !rightBtn) return;
+
+        leftBtn.addEventListener('click', () => {
+            container.scrollBy({ left: -300, behavior: 'smooth' });
+        });
+
+        rightBtn.addEventListener('click', () => {
+            container.scrollBy({ left: 300, behavior: 'smooth' });
         });
     }
 }


### PR DESCRIPTION
## Summary
- add navigation buttons for horizontal scroll in historical data section
- style buttons and enable scrolling in CSS
- initialize scroll controls in `MatchAnalyzer`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883f08284b48321972f24307d318004