### PR TITLE
Fix player search clearing

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -110,6 +110,7 @@ function switchSearchMode(mode) {
         // Hide match analysis results when switching to player mode
         if (resultsDiv) {
             resultsDiv.classList.add('hidden');
+            resultsDiv.innerHTML = '';
         }
         console.log('Switched to player mode - match results hidden');
     }


### PR DESCRIPTION
## Summary
- clear the match analysis results when switching to player search mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688419b635408321991b3b2afb83eadc