### PR TITLE
Remove horizontal scroll from player performance

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -1358,8 +1358,6 @@ section {
 /* Two-column team layout for historical data */
 .teams-container {
     position: relative;
-    overflow-x: auto;
-    scroll-behavior: smooth;
 }
 
 /* Desktop grid layout */
@@ -1416,30 +1414,9 @@ section {
 @media (max-width: 768px) {
     .historical-data-section .team-cards {
         display: grid;
-        grid-auto-flow: column;
-        grid-auto-columns: 200px;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
+        grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
         padding-bottom: 0.5rem;
-    }
-
-    .historical-data-section .team-cards::-webkit-scrollbar {
-        height: 8px;
-    }
-
-    .historical-data-section .team-cards::-webkit-scrollbar-track {
-        background: var(--secondary-bg);
-        border-radius: 4px;
-    }
-
-    .historical-data-section .team-cards::-webkit-scrollbar-thumb {
-        background: var(--accent-cyan);
-        border-radius: 4px;
-    }
-
-    .historical-data-section .player-card {
-        min-width: 200px;
     }
 }
 
@@ -1923,32 +1900,4 @@ section {
     white-space: nowrap;
 }
 
-/* Horizontal scroll buttons for historical section */
-.teams-scroll-btn {
-    display: none;
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    background: rgba(17, 24, 39, 0.8);
-    border: 1px solid rgba(75, 85, 99, 0.6);
-    color: #fff;
-    padding: 0.25rem 0.5rem;
-    border-radius: 9999px;
-    cursor: pointer;
-    z-index: 20;
-}
-
-.teams-scroll-btn-left {
-    left: 0.25rem;
-}
-
-.teams-scroll-btn-right {
-    right: 0.25rem;
-}
-
-@media (min-width: 1024px) {
-    .teams-scroll-btn {
-        display: block;
-    }
-}
 }

--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -567,8 +567,6 @@ class MatchAnalyzer {
 
                 <!-- Two-column layout wrapper -->
                 <div class="teams-container" id="teamsContainer">
-                    <button class="teams-scroll-btn teams-scroll-btn-left" id="teamsScrollLeft">&#9664;</button>
-                    <button class="teams-scroll-btn teams-scroll-btn-right" id="teamsScrollRight">&#9654;</button>
                     <!-- Two-column grid layout -->
                     <div class="teams-grid">
                         <!-- Team 1 Column -->
@@ -975,8 +973,7 @@ class MatchAnalyzer {
         // Add mobile tab functionality
         this.initializeTeamTabs();
 
-        // Add horizontal scroll controls for historical section
-        this.initializeHistoricalScroll();
+
         
     }
 
@@ -1700,24 +1697,6 @@ class MatchAnalyzer {
         });
     }
 
-    /**
-     * Setup horizontal scrolling for historical player section
-     */
-    initializeHistoricalScroll() {
-        const container = document.getElementById('teamsContainer');
-        const leftBtn = document.getElementById('teamsScrollLeft');
-        const rightBtn = document.getElementById('teamsScrollRight');
-
-        if (!container || !leftBtn || !rightBtn) return;
-
-        leftBtn.addEventListener('click', () => {
-            container.scrollBy({ left: -300, behavior: 'smooth' });
-        });
-
-        rightBtn.addEventListener('click', () => {
-            container.scrollBy({ left: 300, behavior: 'smooth' });
-        });
-    }
 }
 
 // Export for use in other files


### PR DESCRIPTION
## Summary
- remove left/right scroll controls from the historical player section
- update CSS for the team cards layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688428af84048321b4c79473cfb990b4