### PR TITLE
Fix net worth column width

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -1649,7 +1649,7 @@ section {
 }
 
 .lane-economics-section .networth-column {
-    width: 100px;
+    width: 80px;
     text-align: right;
 }
 
@@ -1865,7 +1865,7 @@ section {
     }
     
     .networth-column {
-        width: 60px;
+        width: 50px;
     }
     
     .lasthits-column, .denies-column {


### PR DESCRIPTION
## Summary
- update lane economics table widths so Net Worth column matches other columns

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68843c7e99608321b021d0ad5b279cab