### PR TITLE
Improve mobile player card layout

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -353,10 +353,27 @@ section {
     .player-stats-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .player-card {
         min-height: 140px;
         padding: 0.5rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .player-card {
+        flex-direction: row !important;
+        align-items: center;
+        min-height: auto;
+    }
+
+    .player-card .stats {
+        margin-top: 0;
+        width: 100%;
+    }
+
+    .player-card .stats .grid {
+        gap: 0.25rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- add mobile-friendly layout for player cards and update Lane Economics section
- tweak CSS to better handle player cards on small screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68843ef189a883218a6c95b8716ff2a7