### PR TITLE
Update match performance design

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -957,7 +957,7 @@ section {
 .game-stats-section,
 .lane-economics-section,
 .historical-data-section {
-    background: rgba(30, 41, 59, 0.9) !important;
+    background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(17, 24, 39, 0.9)) !important;
     backdrop-filter: blur(16px);
     border: 1px solid var(--border-color);
     border-radius: 1rem;
@@ -1005,6 +1005,15 @@ section {
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
     margin-top: 0.5rem;
     position: relative;
+}
+
+/* Gradient text for section titles */
+.section-title-gradient {
+    background: linear-gradient(90deg, var(--accent-emerald), var(--accent-cyan));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    color: transparent;
 }
 
 /* Table styling for stats sections */
@@ -1546,7 +1555,7 @@ section {
 /* Add alternating row colors for better readability */
 .game-stats-section tbody tr:nth-child(even),
 .lane-economics-section tbody tr:nth-child(even) {
-    background-color: rgba(75, 85, 99, 0.1);
+    background-color: rgba(75, 85, 99, 0.15);
 }
 
 /* Performance table column alignment */

--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -158,8 +158,8 @@ class MatchAnalyzer {
         const gameStatsRows = await this.createGameStatsRows(team0Players, team1Players);
         const mobileCards = await this.createGameStatsCards(team0Players, team1Players);
         return `
-            <section class="game-stats-section animate-fadeInUp bg-gray-800 rounded-lg p-6 mb-8">
-                <h2 class="text-2xl font-bold text-white mb-6 text-center">🎮 Match Performance</h2>
+            <section class="game-stats-section animate-fadeInUp rounded-lg p-6 mb-8">
+                <h2 class="text-2xl font-bold section-title-gradient mb-6 text-center">🎮 Match Performance</h2>
 
                 <!-- Desktop table -->
                 <div class="hidden md:block">
@@ -327,8 +327,8 @@ class MatchAnalyzer {
         const laneEconomicsRows = await this.createLaneEconomicsRows(team0Players, team1Players);
         const mobileCards = await this.createLaneEconomicsCards(team0Players, team1Players);
         return `
-            <section class="lane-economics-section animate-fadeInUp bg-gray-800 rounded-lg p-6 mb-8" style="animation-delay: 0.2s;">
-                <h2 class="text-2xl font-bold text-white mb-6 text-center">💰 Lane Economics & Farm</h2>
+            <section class="lane-economics-section animate-fadeInUp rounded-lg p-6 mb-8" style="animation-delay: 0.2s;">
+                <h2 class="text-2xl font-bold section-title-gradient mb-6 text-center">💰 Lane Economics & Farm</h2>
 
                 <!-- Lane Headers -->
                 <div class="grid grid-cols-2 gap-6 mb-4">
@@ -501,8 +501,8 @@ class MatchAnalyzer {
                     <p class="font-semibold ${textColor} truncate">${this.formatPlayerName(player)}</p>
                     <div class="text-xs text-gray-300 flex space-x-2">
                         <span>NW: ${this.formatNetWorth(player.netWorth || 0)}</span>
-                        <span>LH: ${this.formatTableNumber(player.lastHits || 0)}</span>
-                        <span>D: ${this.formatTableNumber(player.denies || 0)}</span>
+                        <span>Last Hit: ${this.formatTableNumber(player.lastHits || 0)}</span>
+                        <span>Deny: ${this.formatTableNumber(player.denies || 0)}</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- enhance Match Performance and Lane Economics sections
- add gradient titles for sections
- switch lane economics card text from abbreviations to full words

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688445f641e48321ae25f60923ab5b6d