### PR TITLE
Adjust mobile player card sizing

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -310,8 +310,8 @@ section {
     }
     
     .player-card {
-        min-height: 160px;
-        padding: 0.75rem;
+        min-height: 120px;
+        padding: 0.5rem;
         font-size: 0.875rem;
     }
     
@@ -355,7 +355,7 @@ section {
     }
 
     .player-card {
-        min-height: 140px;
+        min-height: 100px;
         padding: 0.5rem;
     }
 }

--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -290,7 +290,7 @@ class MatchAnalyzer {
             const card1 = player1 ? await this.createPerformanceCard(player1, 'red') : '';
 
             cards += `
-                <div class="grid grid-cols-2 gap-2">
+                <div class="grid grid-cols-2 gap-4">
                     <div>${card0}</div>
                     <div>${card1}</div>
                 </div>
@@ -309,7 +309,7 @@ class MatchAnalyzer {
         const borderColor = teamColor === 'green' ? 'border-green-500/30' : 'border-red-500/30';
         const gradientFrom = teamColor === 'green' ? 'from-green-900/10' : 'from-red-900/10';
         return `
-            <div class="player-card bg-gradient-to-br ${gradientFrom} to-gray-800 rounded-lg p-3 flex items-center space-x-2 border ${borderColor}">
+            <div class="player-card bg-gradient-to-br ${gradientFrom} to-gray-800 rounded-lg p-2 flex items-center space-x-2 border ${borderColor}">
                 <div class="hero-icon w-8 h-8 rounded overflow-hidden border" style="border-color: ${this.getHeroColor(player.heroId)};">
                     ${player.heroId && heroImageUrl ? `<img src="${heroImageUrl}" alt="${this.getHeroName(player.heroId)}" class="w-full h-full object-cover">` : ''}
                 </div>
@@ -476,7 +476,7 @@ class MatchAnalyzer {
             const card1 = player1 ? await this.createLaneEconomicsCard(player1, 'red') : '';
 
             cards += `
-                <div class="grid grid-cols-2 gap-2">
+                <div class="grid grid-cols-2 gap-4">
                     <div>${card0}</div>
                     <div>${card1}</div>
                 </div>
@@ -495,7 +495,7 @@ class MatchAnalyzer {
         const borderColor = teamColor === 'green' ? 'border-green-500/30' : 'border-red-500/30';
         const gradientFrom = teamColor === 'green' ? 'from-green-900/10' : 'from-red-900/10';
         return `
-            <div class="player-card bg-gradient-to-br ${gradientFrom} to-gray-800 rounded-lg p-3 flex items-center space-x-2 border ${borderColor}">
+            <div class="player-card bg-gradient-to-br ${gradientFrom} to-gray-800 rounded-lg p-2 flex items-center space-x-2 border ${borderColor}">
                 <div class="hero-icon w-8 h-8 rounded overflow-hidden border" style="border-color: ${this.getHeroColor(player.heroId)};">
                     ${player.heroId && heroImageUrl ? `<img src="${heroImageUrl}" alt="${this.getHeroName(player.heroId)}" class="w-full h-full object-cover">` : ''}
                 </div>


### PR DESCRIPTION
## Summary
- reduce padding on mobile player cards
- expand gap between paired cards in mobile layout
- shrink mobile card min-heights

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68844a3c56a4832191fbd0c3856c0ef2