### PR TITLE
Adjust mobile player card spacing

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -310,9 +310,9 @@ section {
     }
     
     .player-card {
-        min-height: 120px;
-        padding: 0.5rem;
-        font-size: 0.875rem;
+        min-height: 140px;
+        padding: 0.75rem;
+        font-size: 0.9rem;
     }
     
     .player-card .hero-icon {
@@ -355,16 +355,14 @@ section {
     }
 
     .player-card {
-        min-height: 100px;
-        padding: 0.5rem;
+        min-height: 140px;
+        padding: 0.75rem;
     }
 }
 
 @media (max-width: 640px) {
     .player-card {
-        flex-direction: row !important;
-        align-items: center;
-        min-height: auto;
+        min-height: 140px;
     }
 
     .player-card .stats {


### PR DESCRIPTION
## Summary
- increase padding and min-height for player cards on small screens
- simplify mobile rule so cards stay vertical

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68844c248e848321964267ef665421a2