### PR TITLE
Add steam display name to player profile

### DIFF
--- a/public/js/data-models.js
+++ b/public/js/data-models.js
@@ -101,6 +101,8 @@ class PlayerProfile {
     constructor(rawData) {
         this.steamId = rawData.steam_id || rawData.account_id;
         this.playerName = rawData.player_name || rawData.name;
+        // Steam display name if available
+        this.displayName = rawData.displayName || rawData.personaname || null;
         this.avatar = rawData.avatar;
         this.profileUrl = rawData.profile_url;
         

--- a/public/js/deadlock-api-service.js
+++ b/public/js/deadlock-api-service.js
@@ -105,7 +105,21 @@ class DeadlockAPIService {
      */
     async getPlayerProfile(playerId) {
         const url = `${this.baseUrl}/players/${playerId}`;
-        return await this.fetchWithCache(url);
+        const profileData = await this.fetchWithCache(url);
+
+        // Try to enrich the profile with the Steam display name
+        try {
+            const steamData = await this.getSteamUsers([playerId]);
+            const players = steamData?.response?.players;
+            if (players && players.length > 0) {
+                profileData.displayName = players[0].personaname;
+                profileData.personaname = players[0].personaname;
+            }
+        } catch (err) {
+            console.warn('Failed to fetch Steam display name', err);
+        }
+
+        return profileData;
     }
 
     /**


### PR DESCRIPTION
## Summary
- enrich player profiles with Steam display name
- expose display name in PlayerProfile data model

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68844c5525508321b09521f281193f67