### PR TITLE
Fix mobile spacing for player cards

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -305,13 +305,13 @@ section {
 
 @media (max-width: 768px) {
     .player-stats-grid {
-        grid-template-columns: repeat(2, 1fr);
-        gap: 0.5rem;
+        grid-template-columns: 1fr;
+        gap: 1rem;
     }
     
     .player-card {
-        min-height: 120px;
-        padding: 0.5rem;
+        min-height: 160px;
+        padding: 1rem;
         font-size: 0.875rem;
     }
     
@@ -362,8 +362,8 @@ section {
 
 @media (max-width: 640px) {
     .player-card {
-        flex-direction: row !important;
-        align-items: center;
+        flex-direction: column !important;
+        align-items: stretch;
         min-height: auto;
     }
 


### PR DESCRIPTION
## Summary
- improve player card layout on small screens
- keep cards in a single column and maintain vertical layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688454eee2888321b8d8cc46969c4a78