### PR TITLE
Restore desktop layout

### DIFF
--- a/public/enhanced-styles.css
+++ b/public/enhanced-styles.css
@@ -1397,7 +1397,36 @@ section {
 
 @media (min-width: 1024px) {
     .teams-grid {
+        display: flex;
+        gap: 2rem;
+        width: max-content;
+    }
+
+    .teams-tabs {
         display: none;
+    }
+
+    .teams-grid .team-cards {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        max-height: 70vh;
+        overflow-y: auto;
+        padding-right: 0.5rem;
+    }
+
+    .teams-grid .team-cards::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    .teams-grid .team-cards::-webkit-scrollbar-track {
+        background: var(--secondary-bg);
+        border-radius: 3px;
+    }
+
+    .teams-grid .team-cards::-webkit-scrollbar-thumb {
+        background: var(--accent-cyan);
+        border-radius: 3px;
     }
 }
 

--- a/public/js/match-analyzer.js
+++ b/public/js/match-analyzer.js
@@ -693,8 +693,32 @@ class MatchAnalyzer {
             <section class="historical-data-section animate-fadeInUp bg-gray-800 rounded-lg p-6 mb-8" style="animation-delay: 0.4s;">
                 <h2 class="text-2xl font-bold text-white mb-6 text-center">📊 Player Historical Performance</h2>
 
-                <!-- Tabbed layout for both desktop and mobile -->
-                <div class="teams-tabs" id="teamsContainer">
+                <!-- Desktop: two column layout -->
+                <div class="hidden lg:block">
+                    <div class="teams-container">
+                        <div class="teams-grid">
+                            <div class="team-column">
+                                <div class="team-header team-header-green">
+                                    <h4 class="text-lg font-semibold text-green-400">Team 1 Historical Stats</h4>
+                                </div>
+                                <div class="team-cards player-stats-grid">
+                                    ${team0Cards}
+                                </div>
+                            </div>
+                            <div class="team-column">
+                                <div class="team-header team-header-red">
+                                    <h4 class="text-lg font-semibold text-red-400">Team 2 Historical Stats</h4>
+                                </div>
+                                <div class="team-cards player-stats-grid">
+                                    ${team1Cards}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Mobile/tab layout -->
+                <div class="teams-tabs lg:hidden" id="teamsContainer">
                     <div class="tab-buttons">
                         <button class="team-tab-btn team1-tab active" data-team="team1">Team 1</button>
                         <button class="team-tab-btn team2-tab" data-team="team2">Team 2</button>
@@ -1667,7 +1691,30 @@ class MatchAnalyzer {
         }
         
         return `
-            <div class="teams-tabs">
+            <div class="hidden lg:block">
+                <div class="teams-container">
+                    <div class="teams-grid">
+                        <div class="team-column">
+                            <div class="team-header team-header-green">
+                                <h4 class="text-lg font-semibold text-green-400">Team 1</h4>
+                            </div>
+                            <div class="team-cards">
+                                ${(await Promise.all(team0Limited.map((player, index) => player ? this.createLoadingPlayerCard(player, 'green') : Promise.resolve(this.createEmptyLoadingSlot('green', index + 1))))).join('')}
+                            </div>
+                        </div>
+                        <div class="team-column">
+                            <div class="team-header team-header-red">
+                                <h4 class="text-lg font-semibold text-red-400">Team 2</h4>
+                            </div>
+                            <div class="team-cards">
+                                ${(await Promise.all(team1Limited.map((player, index) => player ? this.createLoadingPlayerCard(player, 'red') : Promise.resolve(this.createEmptyLoadingSlot('red', index + 1))))).join('')}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="teams-tabs lg:hidden">
                 <div class="tab-buttons">
                     <button class="team-tab-btn team1-tab active" data-team="team1">Team 1</button>
                     <button class="team-tab-btn team2-tab" data-team="team2">Team 2</button>


### PR DESCRIPTION
## Summary
- adjust CSS for `.teams-grid` to re-enable desktop view
- show two-column grid on large screens while keeping mobile tabs
- ensure loading cards support desktop layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bef3578048321bdc9c789ce015c80