### PR TITLE
Rename quick select option to M Vestappen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
                         <div class="custom-select-wrapper">
                             <select id="playerProfileDropdown" class="w-full enhanced-input text-white rounded-md p-3 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition">
                                 <option value="" disabled selected>Select a player...</option>
-                                <option value="https://steamcommunity.com/profiles/76561198148166542/">🎮 Player Profile 1</option>
+                                <option value="https://steamcommunity.com/profiles/76561198148166542/">🎮 M Vestappen</option>
                                 <option value="https://steamcommunity.com/id/TheDolanizor">👤 TheDolanizor</option>
                                 <option value="https://steamcommunity.com/profiles/76561199836706201">🎮 Player Profile 2</option>
                                 <option value="https://steamcommunity.com/profiles/76561198152972921">🎮 Player Profile 3</option>


### PR DESCRIPTION
## Summary
- label player dropdown option with M Vestappen instead of placeholder Player Profile 1

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68917ed941948321baae2f58b7445586