### PR TITLE
Label quick select options with player names

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,14 +55,14 @@
                         <div class="custom-select-wrapper">
                             <select id="playerProfileDropdown" class="w-full enhanced-input text-white rounded-md p-3 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition">
                                 <option value="" disabled selected>Select a player...</option>
-                                <option value="https://steamcommunity.com/profiles/76561198148166542/">🎮 Player Profile 1</option>
-                                <option value="https://steamcommunity.com/id/TheDolanizor">👤 TheDolanizor</option>
-                                <option value="https://steamcommunity.com/profiles/76561199836706201">🎮 Player Profile 2</option>
-                                <option value="https://steamcommunity.com/profiles/76561198152972921">🎮 Player Profile 3</option>
-                                <option value="https://steamcommunity.com/id/fisting_300_bucks">👤 fisting_300_bucks</option>
-                                <option value="https://steamcommunity.com/id/2Krucial">👤 2Krucial</option>
-                                <option value="https://steamcommunity.com/profiles/76561198106577838">🎮 Player Profile 4</option>
-                                <option value="https://steamcommunity.com/profiles/76561199866750761/">🎮 Player Profile 5</option>
+                                <option value="https://steamcommunity.com/profiles/76561198148166542/">🎮 M Vestappen</option>
+                                <option value="https://steamcommunity.com/id/TheDolanizor">👤 Anthony Bourdain Swag</option>
+                                <option value="https://steamcommunity.com/profiles/76561199836706201">🎮 Frog</option>
+                                <option value="https://steamcommunity.com/profiles/76561198152972921">🎮 I'm Garbage</option>
+                                <option value="https://steamcommunity.com/id/fisting_300_bucks">👤 Pepto-Bismol</option>
+                                <option value="https://steamcommunity.com/id/2Krucial">👤 Mooble</option>
+                                <option value="https://steamcommunity.com/profiles/76561198106577838">🎮 weeweewoowoo</option>
+                                <option value="https://steamcommunity.com/profiles/76561199866750761/">🎮 Bat</option>
                             </select>
                         </div>
                     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -32,31 +32,31 @@ const popularPlayers = [
         url: "https://steamcommunity.com/profiles/76561198148166542/"
     },
     {
-        name: "TheDolanizor",
+        name: "Anthony Bourdain Swag",
         url: "https://steamcommunity.com/id/TheDolanizor"
     },
     {
-        name: "Player Profile 3",
+        name: "Frog",
         url: "https://steamcommunity.com/profiles/76561199836706201"
     },
     {
-        name: "Player Profile 4", 
+        name: "I'm Garbage",
         url: "https://steamcommunity.com/profiles/76561198152972921"
     },
     {
-        name: "fisting_300_bucks",
+        name: "Pepto-Bismol",
         url: "https://steamcommunity.com/id/fisting_300_bucks"
     },
     {
-        name: "2Krucial",
+        name: "Mooble",
         url: "https://steamcommunity.com/id/2Krucial"
     },
     {
-        name: "Player Profile 7",
+        name: "weeweewoowoo",
         url: "https://steamcommunity.com/profiles/76561198106577838"
     },
     {
-        name: "Player Profile 8",
+        name: "Bat",
         url: "https://steamcommunity.com/profiles/76561199866750761/"
     }
 ];


### PR DESCRIPTION
## Summary
- Replace placeholder quick-select dropdown labels with actual player names like Frog, I'm Garbage, and Bat
- Update `popularPlayers` array to keep names in sync with the dropdown

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68917ed941948321baae2f58b7445586