### PR TITLE
feat: show team average rank

### DIFF
--- a/public/js/deadlock-api-service.js
+++ b/public/js/deadlock-api-service.js
@@ -123,6 +123,29 @@ class DeadlockAPIService {
     }
 
     /**
+     * Fetch a player's current rank
+     * @param {string} playerId - The player's Steam ID
+     * @returns {Promise<number|null>} Numeric rank value or null if unavailable
+     */
+    async getPlayerRank(playerId) {
+        const url = `${this.baseUrl}/players/${playerId}/rank`;
+        try {
+            const data = await this.fetchWithCache(url);
+            // Some endpoints may return { rank: X } while others return the number directly
+            if (typeof data === 'number') {
+                return data;
+            }
+            if (data && typeof data.rank !== 'undefined') {
+                return data.rank;
+            }
+            return data?.rank_tier ?? data?.rankTier ?? null;
+        } catch (err) {
+            console.warn(`Failed to fetch rank for ${playerId}`, err);
+            return null;
+        }
+    }
+
+    /**
      * Get player match history with pagination
      * @param {string} playerId - The player's Steam ID
      * @param {number} limit - Number of matches to fetch (default: 50)


### PR DESCRIPTION
## Summary
- compute each team's average rank and show it alongside win rate and KDA
- load player profile data to retrieve rank information during match analysis
- fetch player rank via API instead of relying on profile payloads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689185b8e3248321b9cb470fcf69a87b