### PR TITLE
feat: add hero item stats tabs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -96,6 +96,19 @@
                             </div>
                         </div>
                     </div>
+
+                    <!-- Hero item stats section -->
+                    <div id="heroStatsSection" class="glass-effect p-6 rounded-lg shadow-lg mb-6 hidden">
+                        <div class="flex justify-between items-center mb-4">
+                            <h3 class="text-lg font-semibold text-white">Hero Item Stats</h3>
+                            <select id="heroSortSelect" class="bg-gray-700 text-white text-sm rounded-md p-2">
+                                <option value="matches">Most Played</option>
+                                <option value="hero">Hero Name</option>
+                            </select>
+                        </div>
+                        <div id="heroStatsTabs" class="flex flex-wrap gap-2 mb-4"></div>
+                        <div id="heroStatsContent"></div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add hero item stats section with sorting
- fetch hero build data and show item win/usage/confidence rates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894b82a7d248321956295750c87ac42